### PR TITLE
Compute per-vertex average cortical BMD and thickness

### DIFF
--- a/toolbox/+microCT/accumVertexData.m
+++ b/toolbox/+microCT/accumVertexData.m
@@ -1,0 +1,65 @@
+function Y = accumVertexData(F, UV, I, X)
+%ACCUMVERTEXDATA Accumulates densly sampled surface data and compute a
+%per-vertex mean value.
+%
+%  Y = accumVertexData(F, UV, I, X)
+%
+%    F - Mx3 triangle matrix containing vertex indices
+%    UV - Nx2 matrix of sample barycentric coordinates
+%    I - Nx1 vector of per-sample triangle indices
+%    X - NxK per-sample input matrix
+%
+%    Y - max(F(:))xK output matrix
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
+
+% Compute weights
+W = [UV(:, 1), UV(:, 2), 1 - sum(UV, 2)];
+
+% Copmute weighted inputs
+% XW has dimension size(X, 1) x 3 x size(X, 2)
+XW = W .* permute(X, [1, 3, 2]);
+% reshape to 3 * size(X, 1) x size(X, 2)
+XW = reshape(XW, 3 * size(X, 1), size(X, 2));
+
+% For each point get vertex -> point correspondences.
+% Since each points lies in one triangle, each input point corresponds to
+% 3 vertices, therefore generate 3 index lists pts -> vertex index
+IV = [F(I, 1); F(I, 2); F(I, 3)];
+
+% Accumulate all weighted input that correspond to the same vertex
+N = max(F(:));
+Y = zeros(N, size(X, 2), class(X));
+
+% For each row of the output of accumarray find out with actual vertex
+% index it corresponds to
+IVperm = accumarray(IV, IV, [], @(x) x(1));
+assert(length(IVperm) <= N);
+
+% Compute the number of points per vertex
+SumOfWeightsPerVunorderd = accumarray(IV, W(:), [], @sum);
+% Bring it in the right order
+SumOfWeightsPerV = zeros(N, 1, class(SumOfWeightsPerVunorderd));
+SumOfWeightsPerV(IVperm(IVperm ~= 0)) = SumOfWeightsPerVunorderd(IVperm ~= 0);
+
+% Do the actual accumulation
+for ii=1:size(X, 2)
+  Yi = accumarray(IV, XW(:, ii), [], @sum);
+  % Yi is still in the wrong oder and unreferenced vertices are not
+  % included.
+  % IVperm hold the right vertex indices.
+  Y(IVperm(IVperm ~= 0), ii) = Yi(IVperm ~= 0);
+end
+
+% Normalize output
+Y = Y ./ SumOfWeightsPerV;
+
+% Set all outptu corresponding to unreferenced vertices to NaN
+Y(SumOfWeightsPerV == 0, :) = NaN;
+
+end
+

--- a/toolbox/+microCT/filterClosePointsQuick.m
+++ b/toolbox/+microCT/filterClosePointsQuick.m
@@ -1,0 +1,39 @@
+function [Pf, IA] = filterClosePointsQuick(P, r)
+%FILTERCLOSEPOINTS Filter out points that have a distance less that r
+%inbetween.
+%  [Pf, IA] = filterClosePoints(P, r)
+%    r is the filter radius
+%    P is a NxM matrix of M-dimensional points
+%    Pf is a KxM matrix of the remaining K M-dimensional points.
+%    IA is a index matrix, so that Pf = P(IA, :)
+%
+% It is not guaranteed that this function filters out all points that meet
+% the filter condition, but it is fast. For exact filtering use
+% uniquetol().
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
+
+  function I = medPointIdx(X)
+    PX = P(X, :);
+    centroid = mean(PX, 1);
+    dist = sum((PX - centroid).^2, 2);
+    [~, iMin] = min(dist, [], 1);
+    I = X(iMin);
+  end
+
+N = size(P, 1);
+griddedP = round(P ./ (sqrt(3) * r));
+
+[~, ~, IB] = unique(griddedP, 'rows');
+
+% For each gridded point, find the central point of all points inside the
+% grid cell
+IA = accumarray(IB, (1:N)', [], @medPointIdx);
+Pf = P(IA, :);
+
+end
+

--- a/toolbox/+microCT/genMeshSamples.m
+++ b/toolbox/+microCT/genMeshSamples.m
@@ -1,0 +1,50 @@
+function [Vnew, UVnew, Inew, Nnew, CtThnew] = genMeshSamples(F, V, CtTh)
+%GENMESHSAMPLES Summary of this function goes here
+%   Detailed explanation goes here
+
+TR = triangulation(F, V);
+
+N = TR.vertexNormal;
+
+Subdivs = floor(microCT.meshTriangleMaxEdgeLength(F, V)) + 1;
+
+UniqueSubdivs = unique(Subdivs);
+
+Vnew = [];
+Nnew = [];
+UVnew = [];
+Inew = [];
+
+for si=1:length(UniqueSubdivs)
+  
+  sdiv = UniqueSubdivs(si);
+  FL = Subdivs == sdiv;
+  FI = find(FL);
+  
+  [Vi, UVi, Ii, Ni] = microCT.subsampleTriangulation(V, F(FL, :), sdiv, N);
+  
+  Ii = FI(Ii);
+  
+  Vnew = [Vnew; Vi];
+  Nnew = [Nnew; Ni];
+  UVnew = [UVnew; UVi];
+  Inew = [Inew; Ii];
+  
+end
+
+[Vnew, IA, ~] = uniquetol(Vnew, 0.5/max(abs(V(:))), 'ByRows', true);
+Nnew = Nnew(IA, :);
+UVnew = UVnew(IA, :);
+Inew = Inew(IA);
+
+% Normalize normals
+Nnew = Nnew ./ sqrt(sum(Nnew.^2, 2));
+
+% Compute per sample CtTh
+CtThnew = ...
+  CtTh(F(Inew, 1)) .* UVnew(:, 1) + ...
+  CtTh(F(Inew, 2)) .* UVnew(:, 2) + ...
+  CtTh(F(Inew, 3)) .* (1 - sum(UVnew, 2));
+
+end
+

--- a/toolbox/+microCT/genMeshSamples.m
+++ b/toolbox/+microCT/genMeshSamples.m
@@ -2,7 +2,7 @@ function [Vnew, UVnew, Inew, Nnew, CtThnew] = genMeshSamples(F, V, CtTh)
 %GENMESHSAMPLES Summary of this function goes here
 %   Detailed explanation goes here
 
-TR = triangulation(F, V);
+TR = triangulation(double(F), double(V));
 
 N = TR.vertexNormal;
 
@@ -10,12 +10,14 @@ Subdivs = floor(microCT.meshTriangleMaxEdgeLength(F, V)) + 1;
 
 UniqueSubdivs = unique(Subdivs);
 
-Vnew = [];
-Nnew = [];
-UVnew = [];
-Inew = [];
+nSubdivs = length(UniqueSubdivs);
 
-for si=1:length(UniqueSubdivs)
+Vnew = cell(nSubdivs, 1);
+Nnew = cell(nSubdivs, 1);
+UVnew = cell(nSubdivs, 1);
+Inew = cell(nSubdivs, 1);
+
+parfor si=1:nSubdivs
   
   sdiv = UniqueSubdivs(si);
   FL = Subdivs == sdiv;
@@ -25,14 +27,20 @@ for si=1:length(UniqueSubdivs)
   
   Ii = FI(Ii);
   
-  Vnew = [Vnew; Vi];
-  Nnew = [Nnew; Ni];
-  UVnew = [UVnew; UVi];
-  Inew = [Inew; Ii];
+  Vnew{si} = Vi;
+  Nnew{si} = Ni;
+  UVnew{si} = UVi;
+  Inew{si} = Ii;
   
 end
 
-[Vnew, IA, ~] = uniquetol(Vnew, 0.5/max(abs(V(:))), 'ByRows', true);
+Vnew = cell2mat(Vnew);
+Nnew = cell2mat(Nnew);
+UVnew = cell2mat(UVnew);
+Inew = cell2mat(Inew);
+
+% [Vnew, IA, ~] = uniquetol(Vnew, 0.5/max(abs(V(:))), 'ByRows', true);
+[Vnew, IA] = microCT.filterClosePointsQuick(Vnew, 0.5);
 Nnew = Nnew(IA, :);
 UVnew = UVnew(IA, :);
 Inew = Inew(IA);

--- a/toolbox/+microCT/genMeshSamples.m
+++ b/toolbox/+microCT/genMeshSamples.m
@@ -1,6 +1,24 @@
 function [Vnew, UVnew, Inew, Nnew, CtThnew] = genMeshSamples(F, V, CtTh)
-%GENMESHSAMPLES Summary of this function goes here
-%   Detailed explanation goes here
+%GENMESHSAMPLES Densly subsample the given mesh so that there is at least
+%one sample per voxel intersecting the mesh.
+%
+%  [Vnew, UVnew, Inew, Nnew, CtThnew] = genMeshSamples(F, V, CtTh)
+%
+%    F - Mx3 per triangle vertex index matrix
+%    V - Nx3 vertex position matrix
+%    CtTh - Nx1 vector of per-vertex cortical thickness values
+%
+%    Vnew - Kx3 matrix of sample positions
+%    UVnew - Kx2 matrix of barycentric sample positions
+%    Inew - Kx1 matrix of per-sample triangle index
+%    Nnew - Kx3 matrix of per-sample normals
+%    CtThnew - Kx1 vector of per-sample cortical thickness values
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
 
 TR = triangulation(double(F), double(V));
 

--- a/toolbox/+microCT/meshCortex.m
+++ b/toolbox/+microCT/meshCortex.m
@@ -43,6 +43,14 @@ oldPath = addpath(sprintf('%s/iso2mesh/', rootDir));
 r = max(size(cortexCenterDist))^3 / 2;
 c = size(cortexCenterDist) / 2;
 [V, F] = vol2restrictedtri(double(cortexCenterDist), -1e-9, c, r, 30, 2, 2, 50000);
+V = single(V);
+if length(V) <= intmax('uint16')
+  F = uint16(F);
+elseif length(V) <= intmax('uint32')
+  F = uint32(F);
+else
+  F = uint64(F);
+end
 
 path(oldPath);
 

--- a/toolbox/+microCT/meshCortex.m
+++ b/toolbox/+microCT/meshCortex.m
@@ -42,7 +42,7 @@ oldPath = addpath(sprintf('%s/iso2mesh/', rootDir));
 % Mesh volume
 r = max(size(cortexCenterDist))^3 / 2;
 c = size(cortexCenterDist) / 2;
-[V, F] = vol2restrictedtri(double(cortexCenterDist), -1e-9, c, r, 30, 2, 2, 50000);
+[V, F] = vol2restrictedtri(double(cortexCenterDist), -1e-9, c, r, 30, 5, 0.1, 100000);
 V = single(V);
 if length(V) <= intmax('uint16')
   F = uint16(F);

--- a/toolbox/+microCT/meshCortex.m
+++ b/toolbox/+microCT/meshCortex.m
@@ -32,7 +32,7 @@ scale = 1;
 if nVox > 1e9
   scale = 1e9 / nVox;
   
-  cortexCenterDist = imresize3(cortexCenterDist, scale);
+  cortexCenterDist = imresize3(cortexCenterDist, scale, 'linear');
 end
 
 
@@ -59,6 +59,6 @@ V = (V + 1) / scale - 0.5;
 V = [V(:, 2), V(:, 1), V(:, 3)];
 
 % Sample corticalThickness
-C = interp3(corticalThickness, V(:, 1), V(:, 2), V(:, 3), 'cubic');
+C = interp3(corticalThickness, V(:, 1), V(:, 2), V(:, 3), 'linear');
 
 end

--- a/toolbox/+microCT/meshCortex.m
+++ b/toolbox/+microCT/meshCortex.m
@@ -52,11 +52,17 @@ else
   F = uint64(F);
 end
 
-path(oldPath);
 
 % Undo scaling
 V = V / scale + 0.5;
 V = [V(:, 2), V(:, 1), V(:, 3)];
+
+[V, F] = meshcheckrepair(V, F, 'dup');
+[V, F] = meshcheckrepair(V, F, 'isolated');
+[V, F] = meshcheckrepair(V, F, 'deep');
+[V, F] = meshcheckrepair(V, F, 'meshfix');
+
+path(oldPath);
 
 % Sample corticalThickness
 C = interp3(corticalThickness, V(:, 1), V(:, 2), V(:, 3), 'linear');

--- a/toolbox/+microCT/meshCortex.m
+++ b/toolbox/+microCT/meshCortex.m
@@ -55,7 +55,7 @@ end
 path(oldPath);
 
 % Undo scaling
-V = (V + 1) / scale - 0.5;
+V = V / scale + 0.5;
 V = [V(:, 2), V(:, 1), V(:, 3)];
 
 % Sample corticalThickness

--- a/toolbox/+microCT/meshEdges.m
+++ b/toolbox/+microCT/meshEdges.m
@@ -1,0 +1,20 @@
+function E = meshEdges(F)
+%MESHEDGES Output unique edges of a mesh given py its index set
+%
+%  E = meshEdges(F) - returns unique edges of mesh defined by the face
+%  matrix F.
+%    F is a Nx3 matrix of indices
+%    E is a Mx2 matrix of indices
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
+
+E = reshape([F, F(:, 1)]', 2, []);
+E = sort(E, 1);
+E = unique(E', 'rows');
+
+end
+

--- a/toolbox/+microCT/meshTriangleMaxEdgeLength.m
+++ b/toolbox/+microCT/meshTriangleMaxEdgeLength.m
@@ -1,6 +1,19 @@
 function L = meshTriangleMaxEdgeLength(F, V)
-%MESHTRIANGLEMAXEDGELENGTH Summary of this function goes here
-%   Detailed explanation goes here
+%MESHTRIANGLEMAXEDGELENGTH Compute the maximum edge length for each
+%triangle of the given triangulation.
+%
+%  L = meshTriangleMaxEdgeLength(F, V)
+%
+%    F - Mx3 triangle matrix containing vertex indices
+%    V - Nx3 matrix of vertex positions
+%
+%    L - Mx1 vector of per-triangle maximum edge length
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
 
 
 % circular expansion of F

--- a/toolbox/+microCT/meshTriangleMaxEdgeLength.m
+++ b/toolbox/+microCT/meshTriangleMaxEdgeLength.m
@@ -1,0 +1,20 @@
+function L = meshTriangleMaxEdgeLength(F, V)
+%MESHTRIANGLEMAXEDGELENGTH Summary of this function goes here
+%   Detailed explanation goes here
+
+
+% circular expansion of F
+F = [F, F(:, 1)];
+
+L = zeros(size(F, 1), 1);
+
+for ii = 1:3
+  
+  L = max(L, sum((V(F(:, ii + 1), :) - V(F(:, ii), :)).^2, 2));
+  
+end
+
+L = sqrt(L);
+
+end
+

--- a/toolbox/+microCT/sampleCortexVolume.m
+++ b/toolbox/+microCT/sampleCortexVolume.m
@@ -1,0 +1,74 @@
+function [CtBMD, Ns] = sampleCortexVolume(Img, V, N, CtTh)
+%SAMPLECORTEXVOLUME Samples the cortex volume along profiles through the
+%given vertices along the given normals and return the BMD values at the
+%sampling positions
+%
+%  [CtBMD, Ns] = sampleCortexVolume(Img, V, N, CtTh)
+%    Img - volume to sample (grayscale floating point)
+%    V - Nx3 matrix containing vertex positions
+%    N - Nx3 matrix of per-vertex normals
+%    CtTh - N21 vector of per-vertex cortical thickness values
+%
+%    CtBMD - Nx1 vector of mean BMD values accumulated along profiles through V
+%      along N.
+%    Ns - Nx1 vector containing the number of samples acquired per profile
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
+
+CtTh = ceil(CtTh/2);
+
+maxTh = max(CtTh(isfinite(CtTh)));
+minTh = -maxTh;
+
+dTh = 0.5;
+
+ths = [minTh : dTh : maxTh, 0];
+
+V = single(V);
+N = single(N);
+CtTh = single(CtTh);
+CtTh(~isfinite(CtTh)) = NaN;
+
+if length(ths) < intmax('uint8')
+  Nclass = 'uint8';
+elseif length(ths) < intmax('uint16')
+  Nclass = 'uint16';
+elseif length(ths) < intmax('uint32')
+  Nclass = 'uint32';
+else
+  Nclass = 'uint64';
+end
+
+CtBMD = zeros(size(V, 1), 1, 'double');
+Ns = zeros(size(V, 1), 1, Nclass);
+
+for ii=1:length(ths)
+  
+  thi = ths(ii);
+  
+  valid = abs(CtTh) >= abs(thi);
+  
+  Vi = V(valid, :) + thi * N(valid, :);
+  
+  Ni = ones(size(Vi, 1), 1, Nclass);
+  CtBMDi = interp3(single(Img), Vi(:, 1), Vi(:, 2), Vi(:, 3), 'nearest');
+  valid2 = isfinite(CtBMDi);
+  CtBMDi(~valid2) = 0;
+  Ni(~valid2) = 0;
+  
+  Ns(valid) = Ns(valid) + Ni;
+  
+  CtBMD(valid) = CtBMD(valid) + CtBMDi;
+  
+  fprintf('%.1f%%\n', 100 * ii / length(ths));
+  
+end
+
+CtBMD = single(CtBMD ./ double(Ns));
+
+end
+

--- a/toolbox/+microCT/subsampleTriangulation.m
+++ b/toolbox/+microCT/subsampleTriangulation.m
@@ -82,7 +82,7 @@ a = [a1(valid)'; a2(valid)'; a3(valid)'];
 Vnew = T * a;
 Vnew = reshape(Vnew, 3, []);
 
-TI = reshape(repmat(1:M, size(a, 2), 1), [], 1);
+TI = reshape(repmat((1:M)', 1, size(a, 2)), [], 1);
 UV = repmat(a(1:2, :)', M, 1);
 
 if nargout == 4

--- a/toolbox/+microCT/subsampleTriangulation.m
+++ b/toolbox/+microCT/subsampleTriangulation.m
@@ -91,7 +91,7 @@ if nargout == 4
 end
 
 % Remove dubplicate vertices
-[Vnew, IA, ~] = uniquetol(Vnew', tol, 'ByRows', true);
+[Vnew, IA] = microCT.filterClosePointsQuick(Vnew', tol);
 
 Inew = TI(IA);
 UVnew = UV(IA, :);

--- a/toolbox/+microCT/subsampleTriangulation.m
+++ b/toolbox/+microCT/subsampleTriangulation.m
@@ -1,14 +1,19 @@
-function [Vnew, Nnew] = subsampleTriangulation(V, F, N, varargin)
+function [Vnew, UVnew, Inew, Nnew] = subsampleTriangulation(V, F, N, varargin)
 %SUBSAMPLETRIANGULATION Subsamples the given triangulation using uniform
 %(non-random) barycentric subsampling.
-%  Vnew = subsampleTriangulation(V, F, N) - subsables the triangulation
+%  [Vnew, UVnew, Inew] = subsampleTriangulation(V, F, N) - subsables the triangulation
 %  given by vertices V and indices F. N is the number of subsamples per
 %  edge.
+%    Vnew is a Kx3 matrix containing the cartesian coordinates of the
+%      samples
+%    UVnew is a Kx2 matreix containing the barycnetric coordinates of the
+%      samples
+%    Inew is a K-vector containing the triangle indices of the samples
 %
-%  Vnew = subsampleTriangulation(V, F, N, tolerance) - additionaly specify
+%  [Vnew, UVnew, Inew] = subsampleTriangulation(V, F, N, tolerance) - additionaly specify
 %  a tolerance below that two points are considered equal, default to 1e-9;
 %
-%  [Vnew, Nnew] = subsampleTriangulation(V, F, N, Normals, ...) -
+%  [Vnew, UVnew, Inew, Nnew] = subsampleTriangulation(V, F, N, Normals, ...) -
 %    also compute per-vertex normals and stores them in Nnew.
 %
 % The used algorithm is quite simple and not very efficient. Since it
@@ -24,7 +29,7 @@ function [Vnew, Nnew] = subsampleTriangulation(V, F, N, varargin)
 
 tol = 1e-9;
 if not(isempty(varargin))
-  if nargout == 1
+  if nargout == 3
     tol = varargin{1};
   else
     if numel(varargin) > 1
@@ -33,7 +38,7 @@ if not(isempty(varargin))
   end
 end
 
-if nargout == 2
+if nargout == 4
   if isempty(varargin)
     error('Must specify per-vertex normals')
   else
@@ -55,7 +60,7 @@ T = reshape(T, 3, []);
 T = mat2cell(T, 3, 3 * ones(M, 1));
 T = cell2mat(T');
 
-if nargout == 2
+if nargout == 4
   NT = Normals(:, 1:3)';
   TN = [NT(:, F(:, 1)); NT(:, F(:, 2)); NT(:, F(:, 3))];
   TN = reshape(TN, 3, []);
@@ -77,7 +82,10 @@ a = [a1(valid)'; a2(valid)'; a3(valid)'];
 Vnew = T * a;
 Vnew = reshape(Vnew, 3, []);
 
-if nargout == 2
+TI = reshape(repmat(1:M, size(a, 2), 1), [], 1);
+UV = repmat(a(1:2, :)', M, 1);
+
+if nargout == 4
   Nnew = TN * a;
   Nnew = reshape(Nnew, 3, []);
 end
@@ -85,7 +93,10 @@ end
 % Remove dubplicate vertices
 [Vnew, IA, ~] = uniquetol(Vnew', tol, 'ByRows', true);
 
-if nargout == 2
+Inew = TI(IA);
+UVnew = UV(IA, :);
+
+if nargout == 4
   
   Nnew = Nnew(:, IA)';
   

--- a/toolbox/+microCT/subsampleTriangulation.m
+++ b/toolbox/+microCT/subsampleTriangulation.m
@@ -1,0 +1,95 @@
+function [Vnew, Nnew] = subsampleTriangulation(V, F, N, varargin)
+%SUBSAMPLETRIANGULATION Subsamples the given triangulation using uniform
+%(non-random) barycentric subsampling.
+%  Vnew = subsampleTriangulation(V, F, N) - subsables the triangulation
+%  given by vertices V and indices F. N is the number of subsamples per
+%  edge.
+%
+%  Vnew = subsampleTriangulation(V, F, N, tolerance) - additionaly specify
+%  a tolerance below that two points are considered equal, default to 1e-9;
+%
+%  [Vnew, Nnew] = subsampleTriangulation(V, F, N, Normals, ...) -
+%    also compute per-vertex normals and stores them in Nnew.
+%
+% The used algorithm is quite simple and not very efficient. Since it
+% produces duplicate vertices at each edge, those duplicates are removed in
+% a brute force filtering step afterwards. Not suited for large
+% triangulations.
+%
+% This file is part of the 'microCT-Toolbox' project.
+% Author: Stefan Reinhold
+% Copyright: Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+%            You may use, distribute and modify this code under the terms of
+%            the AFL 3.0 license; see LICENSE for full license details.
+
+tol = 1e-9;
+if not(isempty(varargin))
+  if nargout == 1
+    tol = varargin{1};
+  else
+    if numel(varargin) > 1
+      tol = varargin{2};
+    end
+  end
+end
+
+if nargout == 2
+  if isempty(varargin)
+    error('Must specify per-vertex normals')
+  else
+    Normals = varargin{1};
+    if size(Normals, 1) ~= size(V, 1)
+      error('Normals must have the same size as V');
+    end
+  end
+  
+end
+
+M = size(F, 1);
+
+% Construct base matrix
+VT = V(:, 1:3)';
+T = [VT(:, F(:, 1)); VT(:, F(:, 2)); VT(:, F(:, 3))];
+T = reshape(T, 3, []);
+
+T = mat2cell(T, 3, 3 * ones(M, 1));
+T = cell2mat(T');
+
+if nargout == 2
+  NT = Normals(:, 1:3)';
+  TN = [NT(:, F(:, 1)); NT(:, F(:, 2)); NT(:, F(:, 3))];
+  TN = reshape(TN, 3, []);
+  
+  TN = mat2cell(TN, 3, 3 * ones(M, 1));
+  TN = cell2mat(TN');
+end
+
+% Construct barycentric coordinates
+alpha = linspace(0, 1, N);
+[a1, a2] = meshgrid(alpha, alpha);
+a3 = 1 - a1 - a2;
+
+valid = a3 >= -N^(-2);
+
+a = [a1(valid)'; a2(valid)'; a3(valid)'];
+
+% Compute new vertices
+Vnew = T * a;
+Vnew = reshape(Vnew, 3, []);
+
+if nargout == 2
+  Nnew = TN * a;
+  Nnew = reshape(Nnew, 3, []);
+end
+
+% Remove dubplicate vertices
+[Vnew, IA, ~] = uniquetol(Vnew', tol, 'ByRows', true);
+
+if nargout == 2
+  
+  Nnew = Nnew(:, IA)';
+  
+end
+
+end
+


### PR DESCRIPTION
Currently the input volume is only sampled sparsely at the vertex position of the mesh. This leads to poor Ct.Th and Ct.BMD estimates.
By densely sampling the mesh the complete cortical volume can be sampled densely. The resulting dense data is then accumulated to per-vertex averages.
This gives more robot estimated.